### PR TITLE
Issue#50 validation rules

### DIFF
--- a/lib/lcformvalidation.d.ts
+++ b/lib/lcformvalidation.d.ts
@@ -65,5 +65,3 @@ export namespace Validators {
   function email(value: any, vm: any): FieldValidationResult;
   function pattern(value: any, vm: any, customParams: PatternParams): FieldValidationResult;
 }
-
-

--- a/lib/lcformvalidation.d.ts
+++ b/lib/lcformvalidation.d.ts
@@ -33,15 +33,37 @@ export interface FieldValidationFunction {
   (value: any, vm: any, customParams: any): ValidationResult;
 }
 
-export interface FieldValidationConstraint{
+export interface FieldValidationConstraint {
   validator: FieldValidationFunction;
   eventFilters?: ValidationEventsFilter;
   customParams?: any;
 }
 
-export interface ValidationConstraints{
+export interface ValidationConstraints {
   global?: FormValidationFunction[];
   fields?: { [key: string]: FieldValidationConstraint[] }
 }
 
 export function createFormValidation(validationCredentials: ValidationConstraints): FormValidation;
+
+export interface LengthParams {
+  length: number;
+}
+
+export interface PatternParams {
+  pattern: string | RegExp;
+}
+
+export interface RequiredParams {
+  trim: boolean;
+}
+
+export namespace Validators {
+  function required(value: any, vm: any, customParams: RequiredParams): FieldValidationResult;
+  function minLength(value: any, vm: any, customParams: LengthParams): FieldValidationResult;
+  function maxLength(value: any, vm: any, customParams: LengthParams): FieldValidationResult;
+  function email(value: any, vm: any): FieldValidationResult;
+  function pattern(value: any, vm: any, customParams: PatternParams): FieldValidationResult;
+}
+
+

--- a/lib/src/index.ts
+++ b/lib/src/index.ts
@@ -1,10 +1,10 @@
 import { FormValidationResult, FieldValidationResult } from "./entities";
 import { createFormValidation } from './baseFormValidation';
-import { validationRules } from './rules';
+import { Validators } from './rules';
 
 export {
   FormValidationResult,
   FieldValidationResult,
   createFormValidation,
-  validationRules,
+  Validators,
 }

--- a/lib/src/index.ts
+++ b/lib/src/index.ts
@@ -1,8 +1,10 @@
 import { FormValidationResult, FieldValidationResult } from "./entities";
 import { createFormValidation } from './baseFormValidation';
+import { validationRules } from './rules';
 
 export {
   FormValidationResult,
   FieldValidationResult,
   createFormValidation,
+  validationRules,
 }

--- a/lib/src/rules/email.ts
+++ b/lib/src/rules/email.ts
@@ -1,0 +1,13 @@
+import { FieldValidationResult, FieldValidationFunction } from '../entities';
+
+// RegExp from http://emailregex.com
+const EMAIL_PATTERN = /^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
+
+export const email: FieldValidationFunction = (value: string, vm, customParams) => {
+  const validationResult = new FieldValidationResult();
+  const isValid = EMAIL_PATTERN.test(value);
+  validationResult.succeeded = isValid;
+  validationResult.type = 'EMAIL';
+  validationResult.errorMessage = isValid ? '' : 'Please enter a valid email address.';
+  return validationResult;
+};

--- a/lib/src/rules/email.ts
+++ b/lib/src/rules/email.ts
@@ -5,10 +5,22 @@ const EMAIL_PATTERN = /^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".
 
 export const email: FieldValidationFunction = (value: string) => {
   const validationResult = new FieldValidationResult();
-  const isValid = EMAIL_PATTERN.test(value);
+  const isValid = isValidEmail(value);
 
   validationResult.succeeded = isValid;
   validationResult.type = 'EMAIL';
   validationResult.errorMessage = isValid ? '' : 'Please enter a valid email address.';
   return validationResult;
 };
+
+function isValidEmail(value): boolean {
+  return isEmptyValue(value) ?
+    true :
+    EMAIL_PATTERN.test(value);
+}
+
+function isEmptyValue(value): boolean {
+  return value === null ||
+    value === undefined ||
+    value === '';
+}

--- a/lib/src/rules/email.ts
+++ b/lib/src/rules/email.ts
@@ -3,7 +3,7 @@ import { FieldValidationResult, FieldValidationFunction } from '../entities';
 // RegExp from http://emailregex.com
 const EMAIL_PATTERN = /^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
 
-export const email: FieldValidationFunction = (value: string, vm, customParams) => {
+export const email: FieldValidationFunction = (value: string) => {
   const validationResult = new FieldValidationResult();
   const isValid = EMAIL_PATTERN.test(value);
   validationResult.succeeded = isValid;

--- a/lib/src/rules/email.ts
+++ b/lib/src/rules/email.ts
@@ -6,6 +6,7 @@ const EMAIL_PATTERN = /^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".
 export const email: FieldValidationFunction = (value: string) => {
   const validationResult = new FieldValidationResult();
   const isValid = EMAIL_PATTERN.test(value);
+
   validationResult.succeeded = isValid;
   validationResult.type = 'EMAIL';
   validationResult.errorMessage = isValid ? '' : 'Please enter a valid email address.';

--- a/lib/src/rules/index.ts
+++ b/lib/src/rules/index.ts
@@ -19,5 +19,5 @@ export const Validators: ValidatorFunctions = {
   minLength,
   maxLength,
   email,
-  pattern
+  pattern,
 };

--- a/lib/src/rules/index.ts
+++ b/lib/src/rules/index.ts
@@ -3,9 +3,18 @@ import { minLength } from './minLength';
 import { maxLength } from './maxLength';
 import { email } from './email';
 import { pattern } from './pattern';
+import { FieldValidationFunction } from '../entities';
 
 
-export const validationRules = {
+interface ValidatorFunctions {
+  required: FieldValidationFunction;
+  minLength: FieldValidationFunction;
+  maxLength: FieldValidationFunction;
+  email: FieldValidationFunction;
+  pattern: FieldValidationFunction;
+}
+
+export const Validators: ValidatorFunctions = {
   required,
   minLength,
   maxLength,

--- a/lib/src/rules/index.ts
+++ b/lib/src/rules/index.ts
@@ -1,0 +1,14 @@
+import { required } from './required';
+import { minLength } from './minLength';
+import { maxLength } from './maxLength';
+import { email } from './email';
+import { pattern } from './pattern';
+
+
+export const validationRules = {
+  required,
+  minLength,
+  maxLength,
+  email,
+  pattern
+};

--- a/lib/src/rules/length.ts
+++ b/lib/src/rules/length.ts
@@ -16,5 +16,8 @@ export function isLengthValid(
   length: number,
   validatorFn: (value: string, length: number) => boolean
 ): boolean {
-  return typeof value === 'string' ? validatorFn(value, length) : true;
+  // Don't try to validate non string values
+  return typeof value === 'string' ?
+    validatorFn(value, length) :
+    true;
 }

--- a/lib/src/rules/length.ts
+++ b/lib/src/rules/length.ts
@@ -11,10 +11,6 @@ export function parseLengthParams(customParams: LengthParams, errorMessage: stri
   return length;
 }
 
-interface LengthValidatorFunction {
-  (value: string, length: number): boolean;
-}
-
 export function isLengthValid(
   value,
   length: number,

--- a/lib/src/rules/length.ts
+++ b/lib/src/rules/length.ts
@@ -20,10 +20,5 @@ export function isLengthValid(
   length: number,
   validatorFn: (value: string, length: number) => boolean
 ): boolean {
-  if (typeof value === 'string') {
-    return validatorFn(value, length);
-  }
-
-  // Don't validate non string values
-  return true;
+  return typeof value === 'string' ? validatorFn(value, length) : true;
 }

--- a/lib/src/rules/length.ts
+++ b/lib/src/rules/length.ts
@@ -1,0 +1,29 @@
+export interface LengthParams {
+  length: number;
+}
+
+export function parseLengthParams(customParams: LengthParams, errorMessage: string) {
+  const length = customParams.length === null ? NaN : Number(customParams.length);
+  if (isNaN(length)) {
+    throw new Error(errorMessage);
+  }
+
+  return length;
+}
+
+interface LengthValidatorFunction {
+  (value: string, length: number): boolean;
+}
+
+export function isLengthValid(
+  value,
+  length: number,
+  validatorFn: (value: string, length: number) => boolean
+): boolean {
+  if (typeof value === 'string') {
+    return validatorFn(value, length);
+  }
+
+  // Don't validate non string values
+  return true;
+}

--- a/lib/src/rules/maxLength.ts
+++ b/lib/src/rules/maxLength.ts
@@ -20,5 +20,7 @@ export function maxLength(value: string, vm, customParams: LengthParams = DEFAUL
 }
 
 function isStringLengthValid(value: string, length: number) {
-  return isNaN(length) ? false : value.length <= length;
+  return isNaN(length) ?
+    false :
+    value.length <= length;
 }

--- a/lib/src/rules/maxLength.ts
+++ b/lib/src/rules/maxLength.ts
@@ -1,37 +1,22 @@
 import { FieldValidationResult, FieldValidationFunction } from '../entities';
+import {
+  LengthParams,
+  parseLengthParams,
+  isLengthValid,
+} from './length';
 
-export interface MaxLengthParams {
-  length: number;
-}
+const DEFAULT_PARAMS = { length: undefined };
+const BAD_PARAMETER = 'FieldValidationError: Parameter "length" for maxLength in customParams is mandatory and should be a valid number. Example: { length: 4 }.';
 
-const defaultParams = { length: undefined };
-export function maxLength(value: string, vm, customParams: MaxLengthParams = defaultParams) {
-  const length = ParseCustomParams(customParams);
-  const isValid = isLengthValid(value, length);
+export function maxLength(value: string, vm, customParams: LengthParams = DEFAULT_PARAMS) {
+  const length = parseLengthParams(customParams, BAD_PARAMETER);
+  const isValid = isLengthValid(value, length, isStringLengthValid);
   const validationResult = new FieldValidationResult();
 
   validationResult.succeeded = isValid;
   validationResult.key = 'MAX_LENGTH';
   validationResult.errorMessage = isValid ? '' : `The value provided is too long. Length must not exceed ${length} characters.`;
   return validationResult;
-}
-
-function ParseCustomParams(customParams: MaxLengthParams) {
-  const length = customParams.length === null ? NaN : Number(customParams.length);
-  if (isNaN(length)) {
-    throw new Error('FieldValidationError: Parameter "length" for maxLength in customParams is mandatory and should be a valid number. Example: { length: 4 }.');
-  }
-
-  return length;
-}
-
-function isLengthValid(value, length: number): boolean {
-  if (typeof value === 'string') {
-    return isStringLengthValid(value, length);
-  }
-
-  // Don't validate non string values
-  return true;
 }
 
 function isStringLengthValid(value: string, length: number) {

--- a/lib/src/rules/maxLength.ts
+++ b/lib/src/rules/maxLength.ts
@@ -19,7 +19,7 @@ export function maxLength(value: string, vm, customParams: LengthParams = DEFAUL
   return validationResult;
 }
 
-function isStringLengthValid(value: string, length: number) {
+function isStringLengthValid(value: string, length: number): boolean {
   return isNaN(length) ?
     false :
     value.length <= length;

--- a/lib/src/rules/maxLength.ts
+++ b/lib/src/rules/maxLength.ts
@@ -14,7 +14,7 @@ export function maxLength(value: string, vm, customParams: LengthParams = DEFAUL
   const validationResult = new FieldValidationResult();
 
   validationResult.succeeded = isValid;
-  validationResult.key = 'MAX_LENGTH';
+  validationResult.type = 'MAX_LENGTH';
   validationResult.errorMessage = isValid ? '' : `The value provided is too long. Length must not exceed ${length} characters.`;
   return validationResult;
 }

--- a/lib/src/rules/maxLength.ts
+++ b/lib/src/rules/maxLength.ts
@@ -1,0 +1,39 @@
+import { FieldValidationResult, FieldValidationFunction } from '../entities';
+
+export interface MaxLengthParams {
+  length: number;
+}
+
+const defaultParams = { length: undefined };
+export function maxLength(value: string, vm, customParams: MaxLengthParams = defaultParams) {
+  const length = ParseCustomParams(customParams);
+  const isValid = isLengthValid(value, length);
+  const validationResult = new FieldValidationResult();
+
+  validationResult.succeeded = isValid;
+  validationResult.key = 'MAX_LENGTH';
+  validationResult.errorMessage = isValid ? '' : `The value provided is too long. Length must not exceed ${length} characters.`;
+  return validationResult;
+}
+
+function ParseCustomParams(customParams: MaxLengthParams) {
+  const length = customParams.length === null ? NaN : Number(customParams.length);
+  if (isNaN(length)) {
+    throw new Error('FieldValidationError: Parameter "length" for maxLength in customParams is mandatory and should be a valid number. Example: { length: 4 }.');
+  }
+
+  return length;
+}
+
+function isLengthValid(value, length: number): boolean {
+  if (typeof value === 'string') {
+    return isStringLengthValid(value, length);
+  }
+
+  // Don't validate non string values
+  return true;
+}
+
+function isStringLengthValid(value: string, length: number) {
+  return isNaN(length) ? false : value.length <= length;
+}

--- a/lib/src/rules/minLength.ts
+++ b/lib/src/rules/minLength.ts
@@ -12,9 +12,10 @@ export const minLength: FieldValidationFunction = (value: string, vm, customPara
   const length = parseLengthParams(customParams, BAD_PARAMETER);
   const isValid = isLengthValid(value, length, isStringLengthValid);
   const validationResult = new FieldValidationResult();
+
   validationResult.errorMessage = isValid ? '' : `The value provided must have at least ${length} characters.`;
   validationResult.succeeded = isValid;
-  validationResult.key = 'MIN_LENGTH';
+  validationResult.type = 'MIN_LENGTH';
   return validationResult;
 }
 

--- a/lib/src/rules/minLength.ts
+++ b/lib/src/rules/minLength.ts
@@ -1,0 +1,38 @@
+import { FieldValidationResult, FieldValidationFunction } from '../entities';
+
+export interface MinLengthParams {
+  length: number;
+}
+
+const defaultParams = { length: undefined };
+export const minLength: FieldValidationFunction = (value: string, vm, customParams: MinLengthParams = defaultParams) => {
+  const length = parseCustomParams(customParams);
+  const isValid = isLengthValid(value, length);
+  const validationResult = new FieldValidationResult();
+  validationResult.errorMessage = isValid ? '' : `The value provided must have at least ${length} characters.`;
+  validationResult.succeeded = isValid;
+  validationResult.key = 'MIN_LENGTH';
+  return validationResult;
+}
+
+function parseCustomParams(customParams: MinLengthParams) {
+  const length = customParams.length === null ? NaN : Number(customParams.length);
+  if (isNaN(length)) {
+    throw new Error('FieldValidationError: Parameter "length" for minLength in customParams is mandatory and should be a valid number. Example: { length: 4 }.');
+  }
+
+  return length;
+}
+
+function isLengthValid(value, length: number): boolean {
+  if (typeof value === 'string') {
+    return isStringLengthValid(value, length);
+  }
+
+  // Don't validate non string values
+  return true;
+}
+
+function isStringLengthValid(value: string, length: number) {
+  return value.length >= length;
+}

--- a/lib/src/rules/minLength.ts
+++ b/lib/src/rules/minLength.ts
@@ -19,6 +19,6 @@ export const minLength: FieldValidationFunction = (value: string, vm, customPara
   return validationResult;
 }
 
-function isStringLengthValid(value: string, length: number) {
+function isStringLengthValid(value: string, length: number): boolean {
   return value.length >= length;
 }

--- a/lib/src/rules/minLength.ts
+++ b/lib/src/rules/minLength.ts
@@ -1,36 +1,21 @@
 import { FieldValidationResult, FieldValidationFunction } from '../entities';
+import {
+  LengthParams,
+  parseLengthParams,
+  isLengthValid,
+} from './length';
 
-export interface MinLengthParams {
-  length: number;
-}
+const DEFAULT_PARAMS = { length: undefined };
+const BAD_PARAMETER = 'FieldValidationError: Parameter "length" for minLength in customParams is mandatory and should be a valid number. Example: { length: 4 }.';
 
-const defaultParams = { length: undefined };
-export const minLength: FieldValidationFunction = (value: string, vm, customParams: MinLengthParams = defaultParams) => {
-  const length = parseCustomParams(customParams);
-  const isValid = isLengthValid(value, length);
+export const minLength: FieldValidationFunction = (value: string, vm, customParams: LengthParams = DEFAULT_PARAMS) => {
+  const length = parseLengthParams(customParams, BAD_PARAMETER);
+  const isValid = isLengthValid(value, length, isStringLengthValid);
   const validationResult = new FieldValidationResult();
   validationResult.errorMessage = isValid ? '' : `The value provided must have at least ${length} characters.`;
   validationResult.succeeded = isValid;
   validationResult.key = 'MIN_LENGTH';
   return validationResult;
-}
-
-function parseCustomParams(customParams: MinLengthParams) {
-  const length = customParams.length === null ? NaN : Number(customParams.length);
-  if (isNaN(length)) {
-    throw new Error('FieldValidationError: Parameter "length" for minLength in customParams is mandatory and should be a valid number. Example: { length: 4 }.');
-  }
-
-  return length;
-}
-
-function isLengthValid(value, length: number): boolean {
-  if (typeof value === 'string') {
-    return isStringLengthValid(value, length);
-  }
-
-  // Don't validate non string values
-  return true;
 }
 
 function isStringLengthValid(value: string, length: number) {

--- a/lib/src/rules/pattern.ts
+++ b/lib/src/rules/pattern.ts
@@ -27,5 +27,7 @@ function parsePattern({ pattern }: PatternParams): RegExp {
 }
 
 function getRegExp(pattern) {
-  return pattern instanceof RegExp ? pattern : new RegExp(pattern);
+  return pattern instanceof RegExp ?
+    pattern :
+    new RegExp(pattern);
 }

--- a/lib/src/rules/pattern.ts
+++ b/lib/src/rules/pattern.ts
@@ -5,10 +5,12 @@ export interface PatternParams {
 }
 
 const BAD_PARAMETER = 'FieldValidationError: pattern option for pattern validation is mandatory. Example: { pattern: /\d+/ }.';
+
 export function pattern(value: string, vm, customParams: PatternParams): FieldValidationResult {
   const pattern = parsePattern(customParams);
   const isValid = pattern.test(value);
   const validationResult = new FieldValidationResult();
+
   validationResult.succeeded = isValid;
   validationResult.type = 'PATTERN';
   validationResult.errorMessage = isValid ? '' : `Please provide a valid format.`;
@@ -17,18 +19,13 @@ export function pattern(value: string, vm, customParams: PatternParams): FieldVa
 }
 
 function parsePattern({ pattern }: PatternParams): RegExp {
-  if (pattern === undefined || pattern === null) {
+  // Avoid RegExp like /true/ /false/ and /null/ without an explicit "true", "false" or "null"
+  if (typeof pattern === 'boolean' || pattern === null) {
     throw new Error(BAD_PARAMETER);
   }
   return getRegExp(pattern);
 }
 
 function getRegExp(pattern) {
-  if (typeof pattern === 'string') {
-    return new RegExp(`^${pattern}$`);
-  }
-  if (pattern instanceof RegExp) {
-    return pattern;
-  }
-  return new RegExp(pattern);
+  return pattern instanceof RegExp ? pattern : new RegExp(pattern);
 }

--- a/lib/src/rules/pattern.ts
+++ b/lib/src/rules/pattern.ts
@@ -1,0 +1,33 @@
+import { FieldValidationResult } from '../entities';
+
+export interface PatternParams {
+  pattern: string | RegExp;
+}
+
+export function pattern(value: string, vm, customParams: PatternParams): FieldValidationResult {
+  const pattern = parsePattern(customParams);
+  const isValid = pattern.test(value);
+  const validationResult = new FieldValidationResult();
+  validationResult.succeeded = isValid;
+  validationResult.type = 'PATTERN';
+  validationResult.errorMessage = isValid ? '' : `Please provide a valid format.`;
+
+  return validationResult;
+}
+
+function parsePattern({ pattern }: PatternParams): RegExp {
+  if (pattern === undefined || pattern === null) {
+    throw new Error('FieldValidationError: pattern option for pattern validation is mandatory. Example: { pattern: /\d+/ }.');
+  }
+  return getRegExp(pattern);
+}
+
+function getRegExp(pattern) {
+  if (typeof pattern === 'string') {
+    return new RegExp(`^${pattern}$`);
+  }
+  if (pattern instanceof RegExp) {
+    return pattern;
+  }
+  return new RegExp(pattern);
+}

--- a/lib/src/rules/pattern.ts
+++ b/lib/src/rules/pattern.ts
@@ -4,6 +4,7 @@ export interface PatternParams {
   pattern: string | RegExp;
 }
 
+const BAD_PARAMETER = 'FieldValidationError: pattern option for pattern validation is mandatory. Example: { pattern: /\d+/ }.';
 export function pattern(value: string, vm, customParams: PatternParams): FieldValidationResult {
   const pattern = parsePattern(customParams);
   const isValid = pattern.test(value);
@@ -17,7 +18,7 @@ export function pattern(value: string, vm, customParams: PatternParams): FieldVa
 
 function parsePattern({ pattern }: PatternParams): RegExp {
   if (pattern === undefined || pattern === null) {
-    throw new Error('FieldValidationError: pattern option for pattern validation is mandatory. Example: { pattern: /\d+/ }.');
+    throw new Error(BAD_PARAMETER);
   }
   return getRegExp(pattern);
 }

--- a/lib/src/rules/pattern.ts
+++ b/lib/src/rules/pattern.ts
@@ -26,7 +26,7 @@ function parsePattern({ pattern }: PatternParams): RegExp {
   return getRegExp(pattern);
 }
 
-function getRegExp(pattern) {
+function getRegExp(pattern): RegExp {
   return pattern instanceof RegExp ?
     pattern :
     new RegExp(pattern);

--- a/lib/src/rules/required.ts
+++ b/lib/src/rules/required.ts
@@ -5,7 +5,7 @@ export interface RequiredParams {
 
 const DEFAULT_PARAMS: RequiredParams = { trim: false };
 
-export const requiredField: FieldValidationFunction = (value, vm, customParams: RequiredParams = DEFAULT_PARAMS) => {
+export const required: FieldValidationFunction = (value, vm, customParams: RequiredParams = DEFAULT_PARAMS) => {
   const validationResult = new FieldValidationResult();
   const isValid = isValidField(value, Boolean(customParams.trim));
   if (!isValid) {

--- a/lib/src/rules/required.ts
+++ b/lib/src/rules/required.ts
@@ -21,9 +21,13 @@ function isValidField(value, trim: boolean): boolean {
 }
 
 function isNotFalsy(value) {
-  return value !== null && value !== undefined && value !== false;
+  return value !== null &&
+    value !== undefined &&
+    value !== false;
 }
 
 function isStringValid(value: string, trim: boolean): boolean {
-  return trim ? value.trim().length > 0 : value.length > 0;
+  return trim ?
+    value.trim().length > 0 :
+    value.length > 0;
 }

--- a/lib/src/rules/required.ts
+++ b/lib/src/rules/required.ts
@@ -3,7 +3,7 @@ export interface RequiredParams {
   trim: boolean;
 }
 
-const DEFAULT_PARAMS: RequiredParams = { trim: false };
+const DEFAULT_PARAMS: RequiredParams = { trim: true };
 
 export const required: FieldValidationFunction = (value, vm, customParams: RequiredParams = DEFAULT_PARAMS) => {
   const validationResult = new FieldValidationResult();
@@ -21,7 +21,7 @@ function isValidField(value, trim: boolean): boolean {
     return isStringValid(value, trim);
   }
 
-  // Allow only true value
+  // Allow only 'true'
   return value !== null && value !== undefined && value !== false;
 }
 

--- a/lib/src/rules/required.ts
+++ b/lib/src/rules/required.ts
@@ -17,13 +17,7 @@ export const required: FieldValidationFunction = (value, vm, customParams: Requi
 function isValidField(value, trim: boolean): boolean {
   return typeof value === 'string' ?
     isStringValid(value, trim) :
-    isNotFalsy(value);
-}
-
-function isNotFalsy(value) {
-  return value !== null &&
-    value !== undefined &&
-    value !== false;
+    value === true;
 }
 
 function isStringValid(value: string, trim: boolean): boolean {

--- a/lib/src/rules/required.ts
+++ b/lib/src/rules/required.ts
@@ -8,20 +8,19 @@ const DEFAULT_PARAMS: RequiredParams = { trim: true };
 export const required: FieldValidationFunction = (value, vm, customParams: RequiredParams = DEFAULT_PARAMS) => {
   const validationResult = new FieldValidationResult();
   const isValid = isValidField(value, Boolean(customParams.trim));
-  if (!isValid) {
-    validationResult.errorMessage = 'Please fill in this mandatory field.';
-  }
+  validationResult.errorMessage = isValid ? '' : 'Please fill in this mandatory field.';
   validationResult.succeeded = isValid;
   validationResult.type = 'REQUIRED';
   return validationResult;
 }
 
 function isValidField(value, trim: boolean): boolean {
-  if (typeof value === 'string') {
-    return isStringValid(value, trim);
-  }
+  return typeof value === 'string' ?
+    isStringValid(value, trim) :
+    isNotFalsy(value);
+}
 
-  // Allow only 'true'
+function isNotFalsy(value) {
   return value !== null && value !== undefined && value !== false;
 }
 

--- a/lib/src/rules/required.ts
+++ b/lib/src/rules/required.ts
@@ -1,0 +1,30 @@
+import { FieldValidationResult, FieldValidationFunction } from '../entities';
+export interface RequiredParams {
+  trim: boolean;
+}
+
+const DEFAULT_PARAMS: RequiredParams = { trim: false };
+
+export const requiredField: FieldValidationFunction = (value, vm, customParams: RequiredParams = DEFAULT_PARAMS) => {
+  const validationResult = new FieldValidationResult();
+  const isValid = isValidField(value, Boolean(customParams.trim));
+  if (!isValid) {
+    validationResult.errorMessage = 'Please fill in this mandatory field.';
+  }
+  validationResult.succeeded = isValid;
+  validationResult.type = 'REQUIRED';
+  return validationResult;
+}
+
+function isValidField(value, trim: boolean): boolean {
+  if (typeof value === 'string') {
+    return isStringValid(value, trim);
+  }
+
+  // Allow only true value
+  return value !== null && value !== undefined && value !== false;
+}
+
+function isStringValid(value: string, trim: boolean): boolean {
+  return trim ? value.trim().length > 0 : value.length > 0;
+}

--- a/lib/src/rules/spec/email.spec.ts
+++ b/lib/src/rules/spec/email.spec.ts
@@ -1,0 +1,126 @@
+import { email } from '../email';
+import { FieldValidationResult } from '../../entities';
+
+describe('[email] validation rule tests =>', () => {
+  describe('When validating a non string value', () => {
+    it('should return false if value is null', () => {
+      // Arrange
+      const value = null;
+      const vm = undefined;
+      const customParams = undefined;
+
+      // Act
+      const validationResult = email(value, vm, customParams) as FieldValidationResult;
+
+      // Assert
+      expect(validationResult.succeeded).to.be.false;
+      expect(validationResult.type).to.be.equals('EMAIL');
+      expect(validationResult.errorMessage).to.be.equals('Please enter a valid email address.');
+    });
+
+    it('should return false if value is undefined', () => {
+      // Arrange
+      const value = null;
+      const vm = undefined;
+      const customParams = undefined;
+
+      // Act
+      const validationResult = email(value, vm, customParams) as FieldValidationResult;
+
+      // Assert
+      expect(validationResult.succeeded).to.be.false;
+      expect(validationResult.type).to.be.equals('EMAIL');
+      expect(validationResult.errorMessage).to.be.equals('Please enter a valid email address.');
+    });
+
+    it('should return false if value is number', () => {
+      // Arrange
+      const value = Math.PI;
+      const vm = undefined;
+      const customParams = undefined;
+
+      // Act
+      const validationResult = email(value, vm, customParams) as FieldValidationResult;
+
+      // Assert
+      expect(validationResult.succeeded).to.be.false;
+      expect(validationResult.type).to.be.equals('EMAIL');
+      expect(validationResult.errorMessage).to.be.equals('Please enter a valid email address.');
+    });
+
+    it('should return false if value is an object', () => {
+      // Arrange
+      const value = {};
+      const vm = undefined;
+      const customParams = undefined;
+
+      // Act
+      const validationResult = email(value, vm, customParams) as FieldValidationResult;
+
+      // Assert
+      expect(validationResult.succeeded).to.be.false;
+      expect(validationResult.type).to.be.equals('EMAIL');
+      expect(validationResult.errorMessage).to.be.equals('Please enter a valid email address.');
+    });
+
+    it('should return false if value is an array', () => {
+      // Arrange
+      const value = ['a', '@', 'b', '.', 'c', 'o', 'm'];
+      const vm = undefined;
+      const customParams = undefined;
+
+      // Act
+      const validationResult = email(value, vm, customParams) as FieldValidationResult;
+
+      // Assert
+      expect(validationResult.succeeded).to.be.false;
+      expect(validationResult.type).to.be.equals('EMAIL');
+      expect(validationResult.errorMessage).to.be.equals('Please enter a valid email address.');
+    });
+
+    it('should return false if value is a function', () => {
+      // Arrange
+      const value = () => { };
+      const vm = undefined;
+      const customParams = undefined;
+
+      // Act
+      const validationResult = email(value, vm, customParams) as FieldValidationResult;
+
+      // Assert
+      expect(validationResult.succeeded).to.be.false;
+      expect(validationResult.type).to.be.equals('EMAIL');
+      expect(validationResult.errorMessage).to.be.equals('Please enter a valid email address.');
+    });
+  });
+  describe('When validating a string value', () => {
+    it('should return false for invalid email address', () => {
+      // Arrange
+      const value = 'some text';
+      const vm = undefined;
+      const customParams = undefined;
+
+      // Act
+      const validationResult = email(value, vm, customParams) as FieldValidationResult;
+
+      // Assert
+      expect(validationResult.succeeded).to.be.false;
+      expect(validationResult.type).to.be.equals('EMAIL');
+      expect(validationResult.errorMessage).to.be.equals('Please enter a valid email address.');
+    });
+    it('should return true for a valid email address', () => {
+      // Arrange
+      const value = 'a@b.com';
+      const vm = undefined;
+      const customParams = undefined;
+
+      // Act
+      const validationResult = email(value, vm, customParams) as FieldValidationResult;
+
+      // Assert
+      expect(validationResult.succeeded).to.be.true;
+      expect(validationResult.type).to.be.equals('EMAIL');
+      expect(validationResult.errorMessage).to.be.empty;
+    });
+  });
+});

--- a/lib/src/rules/spec/email.spec.ts
+++ b/lib/src/rules/spec/email.spec.ts
@@ -3,7 +3,7 @@ import { FieldValidationResult } from '../../entities';
 
 describe('[email] validation rule tests =>', () => {
   describe('When validating a non string value', () => {
-    it('should return false if value is null', () => {
+    it('should return true if value is null', () => {
       // Arrange
       const value = null;
       const vm = undefined;
@@ -13,12 +13,12 @@ describe('[email] validation rule tests =>', () => {
       const validationResult = email(value, vm, customParams) as FieldValidationResult;
 
       // Assert
-      expect(validationResult.succeeded).to.be.false;
+      expect(validationResult.succeeded).to.be.true;
       expect(validationResult.type).to.be.equals('EMAIL');
-      expect(validationResult.errorMessage).to.be.equals('Please enter a valid email address.');
+      expect(validationResult.errorMessage).to.be.empty;
     });
 
-    it('should return false if value is undefined', () => {
+    it('should return true if value is undefined', () => {
       // Arrange
       const value = undefined;
       const vm = undefined;
@@ -28,9 +28,9 @@ describe('[email] validation rule tests =>', () => {
       const validationResult = email(value, vm, customParams) as FieldValidationResult;
 
       // Assert
-      expect(validationResult.succeeded).to.be.false;
+      expect(validationResult.succeeded).to.be.true;
       expect(validationResult.type).to.be.equals('EMAIL');
-      expect(validationResult.errorMessage).to.be.equals('Please enter a valid email address.');
+      expect(validationResult.errorMessage).to.be.empty;
     });
 
     it('should return false if value is number', () => {

--- a/lib/src/rules/spec/email.spec.ts
+++ b/lib/src/rules/spec/email.spec.ts
@@ -20,7 +20,7 @@ describe('[email] validation rule tests =>', () => {
 
     it('should return false if value is undefined', () => {
       // Arrange
-      const value = null;
+      const value = undefined;
       const vm = undefined;
       const customParams = undefined;
 

--- a/lib/src/rules/spec/maxLength.spec.ts
+++ b/lib/src/rules/spec/maxLength.spec.ts
@@ -43,7 +43,7 @@ describe('[maxLength] validation rule tests =>', () => {
 
       // Assert
       expect(validationResult.succeeded).to.be.true;
-      expect(validationResult.key).to.be.equals('MAX_LENGTH');
+      expect(validationResult.type).to.be.equals('MAX_LENGTH');
       expect(validationResult.errorMessage).to.be.empty;
     });
 
@@ -58,7 +58,7 @@ describe('[maxLength] validation rule tests =>', () => {
 
       // Assert
       expect(validationResult.succeeded).to.be.false;
-      expect(validationResult.key).to.be.equals('MAX_LENGTH');
+      expect(validationResult.type).to.be.equals('MAX_LENGTH');
       expect(validationResult.errorMessage).to.be.equals('The value provided is too long. Length must not exceed 2 characters.');
     });
 
@@ -73,7 +73,7 @@ describe('[maxLength] validation rule tests =>', () => {
 
       // Assert
       expect(validationResult.succeeded).to.be.true;
-      expect(validationResult.key).to.be.equals('MAX_LENGTH');
+      expect(validationResult.type).to.be.equals('MAX_LENGTH');
       expect(validationResult.errorMessage).to.be.empty;
     });
 
@@ -88,7 +88,7 @@ describe('[maxLength] validation rule tests =>', () => {
 
       // Assert
       expect(validationResult.succeeded).to.be.true;
-      expect(validationResult.key).to.be.equals('MAX_LENGTH');
+      expect(validationResult.type).to.be.equals('MAX_LENGTH');
       expect(validationResult.errorMessage).to.be.empty;
     });
   });

--- a/lib/src/rules/spec/maxLength.spec.ts
+++ b/lib/src/rules/spec/maxLength.spec.ts
@@ -15,6 +15,8 @@ describe('[maxLength] validation rule tests =>', () => {
 
       // Assert
       expect(validationResult.succeeded).to.be.true;
+      expect(validationResult.type).to.be.equals('MAX_LENGTH');
+      expect(validationResult.errorMessage).to.be.empty;
     });
 
     it('should return true if value is null', () => {
@@ -28,6 +30,8 @@ describe('[maxLength] validation rule tests =>', () => {
 
       // Assert
       expect(validationResult.succeeded).to.be.true;
+      expect(validationResult.type).to.be.equals('MAX_LENGTH');
+      expect(validationResult.errorMessage).to.be.empty;
     });
   });
 

--- a/lib/src/rules/spec/maxLength.spec.ts
+++ b/lib/src/rules/spec/maxLength.spec.ts
@@ -1,0 +1,119 @@
+import { MaxLengthParams, maxLength } from '../maxLength';
+import { FieldValidationResult } from '../../entities';
+
+describe('[maxLength] validation rule tests =>', () => {
+  describe('When validating a non string value', () => {
+    it('should return true if value is undefined', () => {
+      // Arrange
+      const value = undefined;
+      const vm = undefined;
+      const customParams: MaxLengthParams = { length: 4 };
+
+      // Act
+      const validationResult: FieldValidationResult = maxLength(value, vm, customParams);
+
+      // Assert
+      expect(validationResult.succeeded).to.be.true;
+    });
+
+    it('should return true if value is null', () => {
+      // Arrange
+      const value = null;
+      const vm = undefined;
+      const customParams: MaxLengthParams = { length: 4 };
+
+      // Act
+      const validationResult: FieldValidationResult = maxLength(value, vm, customParams);
+
+      // Assert
+      expect(validationResult.succeeded).to.be.true;
+    });
+  });
+
+  describe('When validating a string value', () => {
+    it('should return true if value length is lesser than length option', () => {
+      // Arrange
+      const value = 'test';
+      const vm = undefined;
+      const customParams: MaxLengthParams = { length: 6 };
+
+      // Act
+      const validationResult: FieldValidationResult = maxLength(value, vm, customParams);
+
+      // Assert
+      expect(validationResult.succeeded).to.be.true;
+      expect(validationResult.key).to.be.equals('MAX_LENGTH');
+      expect(validationResult.errorMessage).to.be.empty;
+    });
+
+    it('should return false if value length is greater than length option', () => {
+      // Arrange
+      const value = 'test';
+      const vm = undefined;
+      const customParams: MaxLengthParams = { length: 2 };
+
+      // Act
+      const validationResult: FieldValidationResult = maxLength(value, vm, customParams);
+
+      // Assert
+      expect(validationResult.succeeded).to.be.false;
+      expect(validationResult.key).to.be.equals('MAX_LENGTH');
+      expect(validationResult.errorMessage).to.be.equals('The value provided is too long. Length must not exceed 2 characters.');
+    });
+
+    it('should return true if value length is equal than length option', () => {
+      // Arrange
+      const value = 'test';
+      const vm = undefined;
+      const customParams: MaxLengthParams = { length: 4 };
+
+      // Act
+      const validationResult: FieldValidationResult = maxLength(value, vm, customParams);
+
+      // Assert
+      expect(validationResult.succeeded).to.be.true;
+      expect(validationResult.key).to.be.equals('MAX_LENGTH');
+      expect(validationResult.errorMessage).to.be.empty;
+    });
+
+    it('should return true if value length is 0 and length option is 0', () => {
+      // Arrange
+      const value = '';
+      const vm = undefined;
+      const customParams: MaxLengthParams = { length: 0 };
+
+      // Act
+      const validationResult: FieldValidationResult = maxLength(value, vm, customParams);
+
+      // Assert
+      expect(validationResult.succeeded).to.be.true;
+      expect(validationResult.key).to.be.equals('MAX_LENGTH');
+      expect(validationResult.errorMessage).to.be.empty;
+    });
+  });
+
+  describe('CustomParams boundaries =>', () => {
+    it('should throw an error if no length option is provided', () => {
+      // Arrange
+      const value = 't';
+      const vm = undefined;
+      const customParams: MaxLengthParams = undefined;
+      const thrownErrorMessage = 'FieldValidationError: Parameter "length" for maxLength in customParams is mandatory and should be a valid number. Example: { length: 4 }.';
+
+      // Act
+      // Assert
+      expect(maxLength.bind(null, value, vm, customParams)).to.throw(Error, thrownErrorMessage);
+    });
+    it('should return false if length is not a valid number', () => {
+      // Arrange
+      const value = 'test';
+      const vm = undefined;
+      const customParams: MaxLengthParams = { length: null };
+      const thrownErrorMessage = 'FieldValidationError: Parameter "length" for maxLength in customParams is mandatory and should be a valid number. Example: { length: 4 }.';
+
+      // Act
+      // Assert
+      expect(maxLength.bind(null, value, vm, customParams)).to.throw(Error, thrownErrorMessage);
+    });
+  });
+});

--- a/lib/src/rules/spec/maxLength.spec.ts
+++ b/lib/src/rules/spec/maxLength.spec.ts
@@ -1,4 +1,5 @@
-import { MaxLengthParams, maxLength } from '../maxLength';
+import { maxLength } from '../maxLength';
+import { LengthParams } from '../length';
 import { FieldValidationResult } from '../../entities';
 
 describe('[maxLength] validation rule tests =>', () => {
@@ -7,7 +8,7 @@ describe('[maxLength] validation rule tests =>', () => {
       // Arrange
       const value = undefined;
       const vm = undefined;
-      const customParams: MaxLengthParams = { length: 4 };
+      const customParams: LengthParams = { length: 4 };
 
       // Act
       const validationResult: FieldValidationResult = maxLength(value, vm, customParams);
@@ -20,7 +21,7 @@ describe('[maxLength] validation rule tests =>', () => {
       // Arrange
       const value = null;
       const vm = undefined;
-      const customParams: MaxLengthParams = { length: 4 };
+      const customParams: LengthParams = { length: 4 };
 
       // Act
       const validationResult: FieldValidationResult = maxLength(value, vm, customParams);
@@ -35,7 +36,7 @@ describe('[maxLength] validation rule tests =>', () => {
       // Arrange
       const value = 'test';
       const vm = undefined;
-      const customParams: MaxLengthParams = { length: 6 };
+      const customParams: LengthParams = { length: 6 };
 
       // Act
       const validationResult: FieldValidationResult = maxLength(value, vm, customParams);
@@ -50,7 +51,7 @@ describe('[maxLength] validation rule tests =>', () => {
       // Arrange
       const value = 'test';
       const vm = undefined;
-      const customParams: MaxLengthParams = { length: 2 };
+      const customParams: LengthParams = { length: 2 };
 
       // Act
       const validationResult: FieldValidationResult = maxLength(value, vm, customParams);
@@ -65,7 +66,7 @@ describe('[maxLength] validation rule tests =>', () => {
       // Arrange
       const value = 'test';
       const vm = undefined;
-      const customParams: MaxLengthParams = { length: 4 };
+      const customParams: LengthParams = { length: 4 };
 
       // Act
       const validationResult: FieldValidationResult = maxLength(value, vm, customParams);
@@ -80,7 +81,7 @@ describe('[maxLength] validation rule tests =>', () => {
       // Arrange
       const value = '';
       const vm = undefined;
-      const customParams: MaxLengthParams = { length: 0 };
+      const customParams: LengthParams = { length: 0 };
 
       // Act
       const validationResult: FieldValidationResult = maxLength(value, vm, customParams);
@@ -97,7 +98,7 @@ describe('[maxLength] validation rule tests =>', () => {
       // Arrange
       const value = 't';
       const vm = undefined;
-      const customParams: MaxLengthParams = undefined;
+      const customParams: LengthParams = undefined;
       const thrownErrorMessage = 'FieldValidationError: Parameter "length" for maxLength in customParams is mandatory and should be a valid number. Example: { length: 4 }.';
 
       // Act
@@ -108,7 +109,7 @@ describe('[maxLength] validation rule tests =>', () => {
       // Arrange
       const value = 'test';
       const vm = undefined;
-      const customParams: MaxLengthParams = { length: null };
+      const customParams: LengthParams = { length: null };
       const thrownErrorMessage = 'FieldValidationError: Parameter "length" for maxLength in customParams is mandatory and should be a valid number. Example: { length: 4 }.';
 
       // Act

--- a/lib/src/rules/spec/minLength.spec.ts
+++ b/lib/src/rules/spec/minLength.spec.ts
@@ -1,0 +1,155 @@
+import { MinLengthParams, minLength } from '../minLength';
+import { FieldValidationResult } from '../../entities';
+
+describe('[minLength] validation rule tests =>', () => {
+  describe('When validating a non string value', () => {
+    it('should return true if value is undefined', () => {
+      // Arrange
+      const value = undefined;
+      const vm = undefined;
+      const customParams: MinLengthParams = { length: 4 };
+
+      // Act
+      const validationResult = minLength(value, vm, customParams) as FieldValidationResult;
+
+      // Assert
+      expect(validationResult.succeeded).to.be.true;
+      expect(validationResult.key).to.be.equals('MIN_LENGTH');
+      expect(validationResult.errorMessage).to.be.empty;
+    });
+
+    it('should return true if value is null', () => {
+      // Arrange
+      const value = null;
+      const vm = undefined;
+      const customParams: MinLengthParams = { length: 4 };
+
+      // Act
+      const validationResult = minLength(value, vm, customParams) as FieldValidationResult;
+
+      // Assert
+      expect(validationResult.succeeded).to.be.true;
+      expect(validationResult.key).to.be.equals('MIN_LENGTH');
+      expect(validationResult.errorMessage).to.be.empty;
+    });
+  });
+
+  describe('When validating a string value', () => {
+    it('should return false for empty strings', () => {
+      // Arrange
+      const value = '';
+      const vm = undefined;
+      const customParams: MinLengthParams = { length: 3 };
+
+      // Act
+      const validationResult = minLength(value, vm, customParams) as FieldValidationResult;
+
+      // Assert
+      expect(validationResult.succeeded).to.be.false;
+      expect(validationResult.errorMessage).to.be.equals('The value provided must have at least 3 characters.');
+      expect(validationResult.key).to.be.equals('MIN_LENGTH');
+    });
+
+    it('should return true if value length is greater than length option', () => {
+      // Arrange
+      const value = 'test';
+      const vm = undefined;
+      const customParams: MinLengthParams = { length: 2 };
+
+      // Act
+      const validationResult = minLength(value, vm, customParams) as FieldValidationResult;
+
+      // Assert
+      expect(validationResult.succeeded).to.be.true;
+      expect(validationResult.errorMessage).to.be.empty;
+      expect(validationResult.key).to.be.equals('MIN_LENGTH');
+    });
+
+    it('should return false if value length is lesser than length option', () => {
+      // Arrange
+      const value = 'test';
+      const vm = undefined;
+      const customParams: MinLengthParams = { length: 6 };
+
+      // Act
+      const validationResult = minLength(value, vm, customParams) as FieldValidationResult;
+
+      // Assert
+      expect(validationResult.succeeded).to.be.false;
+      expect(validationResult.errorMessage).to.be.equals('The value provided must have at least 6 characters.');
+      expect(validationResult.key).to.be.equals('MIN_LENGTH');
+    });
+
+    it('should return true if value length is equal than length option', () => {
+      // Arrange
+      const value = 'test';
+      const vm = undefined;
+      const customParams: MinLengthParams = { length: 4 };
+
+      // Act
+      const validationResult = minLength(value, vm, customParams) as FieldValidationResult;
+
+      // Assert
+      expect(validationResult.succeeded).to.be.true;
+      expect(validationResult.errorMessage).to.be.empty;
+      expect(validationResult.key).to.be.equals('MIN_LENGTH');
+    });
+
+    it('should return true if value has length greater than 0 and length option is 0', () => {
+      // Arrange
+      const value = 'test';
+      const vm = undefined;
+      const customParams: MinLengthParams = { length: 0 };
+
+      // Act
+      const validationResult = minLength(value, vm, customParams) as FieldValidationResult;
+
+      // Assert
+      expect(validationResult.succeeded).to.be.true;
+      expect(validationResult.errorMessage).to.be.empty;
+      expect(validationResult.key).to.be.equals('MIN_LENGTH');
+    });
+
+    it('should return true if valuehas length of 0 and length option is 0', () => {
+      // Arrange
+      const value = '';
+      const vm = undefined;
+      const customParams: MinLengthParams = { length: 0 };
+
+      // Act
+      const validationResult = minLength(value, vm, customParams) as FieldValidationResult;
+
+      // Assert
+      expect(validationResult.succeeded).to.be.true;
+      expect(validationResult.errorMessage).to.be.empty;
+      expect(validationResult.key).to.be.equals('MIN_LENGTH');
+    });
+  });
+
+  describe('CustomParams boundaries =>', () => {
+    it('should throw an error if no length option is provided', () => {
+      // Arrange
+      const value = 't';
+      const vm = undefined;
+      const customParams: MinLengthParams = undefined;
+      const thrownErrorMessage = 'FieldValidationError: Parameter "length" for minLength in customParams is mandatory and should be a valid number. Example: { length: 4 }.';
+
+      // Act
+
+      // Assert
+      expect(minLength.bind(null, value, vm, customParams)).to.throw(Error, thrownErrorMessage);
+    });
+
+    it('should return false if length option is null', () => {
+      // Arrange
+      const value = 'test';
+      const vm = undefined;
+      const customParams: MinLengthParams = { length: null };
+      const thrownErrorMessage = 'FieldValidationError: Parameter "length" for minLength in customParams is mandatory and should be a valid number. Example: { length: 4 }.';
+
+      // Act
+      // Assert
+      expect(minLength.bind(null, value, vm, customParams)).to.throw(Error, thrownErrorMessage);
+    });
+  });
+});

--- a/lib/src/rules/spec/minLength.spec.ts
+++ b/lib/src/rules/spec/minLength.spec.ts
@@ -1,4 +1,5 @@
-import { MinLengthParams, minLength } from '../minLength';
+import { minLength } from '../minLength';
+import { LengthParams } from '../length';
 import { FieldValidationResult } from '../../entities';
 
 describe('[minLength] validation rule tests =>', () => {
@@ -7,7 +8,7 @@ describe('[minLength] validation rule tests =>', () => {
       // Arrange
       const value = undefined;
       const vm = undefined;
-      const customParams: MinLengthParams = { length: 4 };
+      const customParams: LengthParams = { length: 4 };
 
       // Act
       const validationResult = minLength(value, vm, customParams) as FieldValidationResult;
@@ -22,7 +23,7 @@ describe('[minLength] validation rule tests =>', () => {
       // Arrange
       const value = null;
       const vm = undefined;
-      const customParams: MinLengthParams = { length: 4 };
+      const customParams: LengthParams = { length: 4 };
 
       // Act
       const validationResult = minLength(value, vm, customParams) as FieldValidationResult;
@@ -39,7 +40,7 @@ describe('[minLength] validation rule tests =>', () => {
       // Arrange
       const value = '';
       const vm = undefined;
-      const customParams: MinLengthParams = { length: 3 };
+      const customParams: LengthParams = { length: 3 };
 
       // Act
       const validationResult = minLength(value, vm, customParams) as FieldValidationResult;
@@ -54,7 +55,7 @@ describe('[minLength] validation rule tests =>', () => {
       // Arrange
       const value = 'test';
       const vm = undefined;
-      const customParams: MinLengthParams = { length: 2 };
+      const customParams: LengthParams = { length: 2 };
 
       // Act
       const validationResult = minLength(value, vm, customParams) as FieldValidationResult;
@@ -69,7 +70,7 @@ describe('[minLength] validation rule tests =>', () => {
       // Arrange
       const value = 'test';
       const vm = undefined;
-      const customParams: MinLengthParams = { length: 6 };
+      const customParams: LengthParams = { length: 6 };
 
       // Act
       const validationResult = minLength(value, vm, customParams) as FieldValidationResult;
@@ -84,7 +85,7 @@ describe('[minLength] validation rule tests =>', () => {
       // Arrange
       const value = 'test';
       const vm = undefined;
-      const customParams: MinLengthParams = { length: 4 };
+      const customParams: LengthParams = { length: 4 };
 
       // Act
       const validationResult = minLength(value, vm, customParams) as FieldValidationResult;
@@ -99,7 +100,7 @@ describe('[minLength] validation rule tests =>', () => {
       // Arrange
       const value = 'test';
       const vm = undefined;
-      const customParams: MinLengthParams = { length: 0 };
+      const customParams: LengthParams = { length: 0 };
 
       // Act
       const validationResult = minLength(value, vm, customParams) as FieldValidationResult;
@@ -114,7 +115,7 @@ describe('[minLength] validation rule tests =>', () => {
       // Arrange
       const value = '';
       const vm = undefined;
-      const customParams: MinLengthParams = { length: 0 };
+      const customParams: LengthParams = { length: 0 };
 
       // Act
       const validationResult = minLength(value, vm, customParams) as FieldValidationResult;
@@ -131,7 +132,7 @@ describe('[minLength] validation rule tests =>', () => {
       // Arrange
       const value = 't';
       const vm = undefined;
-      const customParams: MinLengthParams = undefined;
+      const customParams: LengthParams = undefined;
       const thrownErrorMessage = 'FieldValidationError: Parameter "length" for minLength in customParams is mandatory and should be a valid number. Example: { length: 4 }.';
 
       // Act
@@ -144,7 +145,7 @@ describe('[minLength] validation rule tests =>', () => {
       // Arrange
       const value = 'test';
       const vm = undefined;
-      const customParams: MinLengthParams = { length: null };
+      const customParams: LengthParams = { length: null };
       const thrownErrorMessage = 'FieldValidationError: Parameter "length" for minLength in customParams is mandatory and should be a valid number. Example: { length: 4 }.';
 
       // Act

--- a/lib/src/rules/spec/minLength.spec.ts
+++ b/lib/src/rules/spec/minLength.spec.ts
@@ -15,7 +15,7 @@ describe('[minLength] validation rule tests =>', () => {
 
       // Assert
       expect(validationResult.succeeded).to.be.true;
-      expect(validationResult.key).to.be.equals('MIN_LENGTH');
+      expect(validationResult.type).to.be.equals('MIN_LENGTH');
       expect(validationResult.errorMessage).to.be.empty;
     });
 
@@ -30,7 +30,7 @@ describe('[minLength] validation rule tests =>', () => {
 
       // Assert
       expect(validationResult.succeeded).to.be.true;
-      expect(validationResult.key).to.be.equals('MIN_LENGTH');
+      expect(validationResult.type).to.be.equals('MIN_LENGTH');
       expect(validationResult.errorMessage).to.be.empty;
     });
   });
@@ -48,7 +48,7 @@ describe('[minLength] validation rule tests =>', () => {
       // Assert
       expect(validationResult.succeeded).to.be.false;
       expect(validationResult.errorMessage).to.be.equals('The value provided must have at least 3 characters.');
-      expect(validationResult.key).to.be.equals('MIN_LENGTH');
+      expect(validationResult.type).to.be.equals('MIN_LENGTH');
     });
 
     it('should return true if value length is greater than length option', () => {
@@ -63,7 +63,7 @@ describe('[minLength] validation rule tests =>', () => {
       // Assert
       expect(validationResult.succeeded).to.be.true;
       expect(validationResult.errorMessage).to.be.empty;
-      expect(validationResult.key).to.be.equals('MIN_LENGTH');
+      expect(validationResult.type).to.be.equals('MIN_LENGTH');
     });
 
     it('should return false if value length is lesser than length option', () => {
@@ -78,7 +78,7 @@ describe('[minLength] validation rule tests =>', () => {
       // Assert
       expect(validationResult.succeeded).to.be.false;
       expect(validationResult.errorMessage).to.be.equals('The value provided must have at least 6 characters.');
-      expect(validationResult.key).to.be.equals('MIN_LENGTH');
+      expect(validationResult.type).to.be.equals('MIN_LENGTH');
     });
 
     it('should return true if value length is equal than length option', () => {
@@ -93,7 +93,7 @@ describe('[minLength] validation rule tests =>', () => {
       // Assert
       expect(validationResult.succeeded).to.be.true;
       expect(validationResult.errorMessage).to.be.empty;
-      expect(validationResult.key).to.be.equals('MIN_LENGTH');
+      expect(validationResult.type).to.be.equals('MIN_LENGTH');
     });
 
     it('should return true if value has length greater than 0 and length option is 0', () => {
@@ -108,7 +108,7 @@ describe('[minLength] validation rule tests =>', () => {
       // Assert
       expect(validationResult.succeeded).to.be.true;
       expect(validationResult.errorMessage).to.be.empty;
-      expect(validationResult.key).to.be.equals('MIN_LENGTH');
+      expect(validationResult.type).to.be.equals('MIN_LENGTH');
     });
 
     it('should return true if valuehas length of 0 and length option is 0', () => {
@@ -123,7 +123,7 @@ describe('[minLength] validation rule tests =>', () => {
       // Assert
       expect(validationResult.succeeded).to.be.true;
       expect(validationResult.errorMessage).to.be.empty;
-      expect(validationResult.key).to.be.equals('MIN_LENGTH');
+      expect(validationResult.type).to.be.equals('MIN_LENGTH');
     });
   });
 

--- a/lib/src/rules/spec/pattern.spec.ts
+++ b/lib/src/rules/spec/pattern.spec.ts
@@ -1,0 +1,95 @@
+import { pattern, PatternParams } from '../pattern';
+import { FieldValidationResult } from '../../entities';
+
+describe('[pattern] validation rule tests =>', () => {
+  describe('Pattern option boundaries =>', () => {
+    it('should throw an error if pattern is null', () => {
+      // Arrange
+      const value = 'test';
+      const vm = undefined;
+      const customParams: PatternParams = { pattern: null };
+      const thrownErrrorMessage = 'FieldValidationError: pattern option for pattern validation is mandatory. Example: { pattern: /\d+/ }.';
+
+      // Act
+      // Assert
+      expect(pattern.bind(null, value, vm, customParams)).to.throw(Error, thrownErrrorMessage);
+    });
+
+    it('should throw an error if pattern is undefined', () => {
+      // Arrange
+      const value = 'test';
+      const vm = undefined;
+      const customParams: PatternParams = { pattern: undefined };
+      const thrownErrrorMessage = 'FieldValidationError: pattern option for pattern validation is mandatory. Example: { pattern: /\d+/ }.';
+
+      // Act
+      // Assert
+      expect(pattern.bind(null, value, vm, customParams)).to.throw(Error, thrownErrrorMessage);
+    });
+  });
+
+  describe('Given a string as RegExp in pattern option', () => {
+    it('should use the entire pattern as a complete pattern', () => {
+      // Arrange
+      const value = 'Some tests needed';
+      const vm = undefined;
+      const customParams: PatternParams = { pattern: 'tests' };
+
+      // Act
+      const validationResult = pattern(value, vm, customParams) as FieldValidationResult;
+
+      // Assert
+      expect(validationResult.succeeded).to.be.false;
+      expect(validationResult.type).to.be.equals('PATTERN');
+      expect(validationResult.errorMessage).to.be.equals('Please provide a valid format.');
+    });
+
+    it('should return true for a value that matches pattern', () => {
+      // Arrange
+      const value = 'test';
+      const vm = undefined;
+      const customParams: PatternParams = { pattern: 'test' };
+
+      // Act
+      const validationResult = pattern(value, vm, customParams) as FieldValidationResult;
+
+      // Assert
+      expect(validationResult.succeeded).to.be.true;
+      expect(validationResult.type).to.be.equals('PATTERN');
+      expect(validationResult.errorMessage).to.be.empty;
+    });
+  });
+
+  describe('Given a RegExp object in pattern option', () => {
+    it('should return true if field value matches the given pattern', () => {
+      // Arrange
+      const value = 'Some tests needed';
+      const vm = undefined;
+      const customParams: PatternParams = { pattern: /tests/ };
+
+      // Act
+      const validationResult = pattern(value, vm, customParams) as FieldValidationResult;
+
+      // Assert
+      expect(validationResult.succeeded).to.be.true;
+      expect(validationResult.type).to.be.equals('PATTERN');
+      expect(validationResult.errorMessage).to.be.empty;
+    });
+
+    it('should return false if field value does not match the given pattern', () => {
+      // Arrange
+      const value = 'Some tests needed';
+      const vm = undefined;
+      const customParams: PatternParams = { pattern: /^tests/ };
+
+      // Act
+      const validationResult = pattern(value, vm, customParams) as FieldValidationResult;
+
+      // Assert
+      expect(validationResult.succeeded).to.be.false;
+      expect(validationResult.type).to.be.equals('PATTERN');
+      expect(validationResult.errorMessage).to.be.equals('Please provide a valid format.');
+    });
+  });
+
+});

--- a/lib/src/rules/spec/pattern.spec.ts
+++ b/lib/src/rules/spec/pattern.spec.ts
@@ -15,11 +15,11 @@ describe('[pattern] validation rule tests =>', () => {
       expect(pattern.bind(null, value, vm, customParams)).to.throw(Error, thrownErrrorMessage);
     });
 
-    it('should throw an error if pattern is undefined', () => {
+    it('should throw an error if pattern is boolean', () => {
       // Arrange
       const value = 'test';
       const vm = undefined;
-      const customParams: PatternParams = { pattern: undefined };
+      const customParams: PatternParams = { pattern: (false as any) };
       const thrownErrrorMessage = 'FieldValidationError: pattern option for pattern validation is mandatory. Example: { pattern: /\d+/ }.';
 
       // Act
@@ -29,7 +29,7 @@ describe('[pattern] validation rule tests =>', () => {
   });
 
   describe('Given a string as RegExp in pattern option', () => {
-    it('should use the entire pattern as a complete pattern', () => {
+    it('should not use the entire pattern as a complete pattern', () => {
       // Arrange
       const value = 'Some tests needed';
       const vm = undefined;
@@ -39,9 +39,9 @@ describe('[pattern] validation rule tests =>', () => {
       const validationResult = pattern(value, vm, customParams) as FieldValidationResult;
 
       // Assert
-      expect(validationResult.succeeded).to.be.false;
+      expect(validationResult.succeeded).to.be.true;
       expect(validationResult.type).to.be.equals('PATTERN');
-      expect(validationResult.errorMessage).to.be.equals('Please provide a valid format.');
+      expect(validationResult.errorMessage).to.be.empty;
     });
 
     it('should return true for a value that matches pattern', () => {

--- a/lib/src/rules/spec/required.spec.ts
+++ b/lib/src/rules/spec/required.spec.ts
@@ -1,4 +1,4 @@
-import { requiredField, RequiredParams } from '../required';
+import { required, RequiredParams } from '../required';
 import { FieldValidationResult } from '../../entities';
 
 describe('[required] validation rule tests =>', () => {
@@ -10,7 +10,7 @@ describe('[required] validation rule tests =>', () => {
       const customParams: RequiredParams = undefined;
 
       // Act
-      const validationResult = requiredField(value, vm, customParams) as FieldValidationResult;
+      const validationResult = required(value, vm, customParams) as FieldValidationResult;
 
       // Assert
       expect(validationResult.succeeded).to.be.false;
@@ -25,7 +25,7 @@ describe('[required] validation rule tests =>', () => {
       const customParams: RequiredParams = undefined;
 
       // Act
-      const validationResult = requiredField(value, vm, customParams) as FieldValidationResult;
+      const validationResult = required(value, vm, customParams) as FieldValidationResult;
 
       // Assert
       expect(validationResult.succeeded).to.be.false;
@@ -40,7 +40,7 @@ describe('[required] validation rule tests =>', () => {
       const customParams: RequiredParams = undefined;
 
       // Act
-      const validationResult = requiredField(value, vm, customParams) as FieldValidationResult;
+      const validationResult = required(value, vm, customParams) as FieldValidationResult;
 
       // Assert
       expect(validationResult.succeeded).to.be.false;
@@ -55,7 +55,7 @@ describe('[required] validation rule tests =>', () => {
       const customParams: RequiredParams = undefined;
 
       // Act
-      const validationResult = requiredField(value, vm, customParams) as FieldValidationResult;
+      const validationResult = required(value, vm, customParams) as FieldValidationResult;
 
       // Assert
       expect(validationResult.succeeded).to.be.true;
@@ -73,7 +73,7 @@ describe('[required] validation rule tests =>', () => {
       const customParams: RequiredParams = undefined;
 
       // Act
-      const validationResult = requiredField(value, vm, customParams) as FieldValidationResult;
+      const validationResult = required(value, vm, customParams) as FieldValidationResult;
 
       // Assert
       expect(validationResult.succeeded).to.be.false;
@@ -88,7 +88,7 @@ describe('[required] validation rule tests =>', () => {
       const customParams: RequiredParams = { trim: false };
 
       // Act
-      const validationResult = requiredField(value, vm, customParams) as FieldValidationResult;
+      const validationResult = required(value, vm, customParams) as FieldValidationResult;
 
       // Assert
       expect(validationResult.succeeded).to.be.true;
@@ -103,7 +103,7 @@ describe('[required] validation rule tests =>', () => {
       const customParams: RequiredParams = { trim: null };
 
       // Act
-      const validationResult = requiredField(value, vm, customParams) as FieldValidationResult;
+      const validationResult = required(value, vm, customParams) as FieldValidationResult;
 
       // Assert
       expect(validationResult.succeeded).to.be.true;
@@ -118,7 +118,7 @@ describe('[required] validation rule tests =>', () => {
       const customParams: RequiredParams = { trim: undefined };
 
       // Act
-      const validationResult = requiredField(value, vm, customParams) as FieldValidationResult;
+      const validationResult = required(value, vm, customParams) as FieldValidationResult;
 
       // Assert
       expect(validationResult.succeeded).to.be.true;
@@ -133,7 +133,7 @@ describe('[required] validation rule tests =>', () => {
       const customParams: RequiredParams = { trim: true };
 
       // Act
-      const validationResult = requiredField(value, vm, customParams) as FieldValidationResult;
+      const validationResult = required(value, vm, customParams) as FieldValidationResult;
 
       // Assert
       expect(validationResult.succeeded).to.be.false;

--- a/lib/src/rules/spec/required.spec.ts
+++ b/lib/src/rules/spec/required.spec.ts
@@ -1,0 +1,144 @@
+import { requiredField, RequiredParams } from '../required';
+import { FieldValidationResult } from '../../entities';
+
+describe('[required] validation rule tests =>', () => {
+  describe('When validating a non string value', () => {
+    it('should return false if value is null', () => {
+      // Arrange
+      const value = null;
+      const vm = undefined;
+      const customParams: RequiredParams = undefined;
+
+      // Act
+      const validationResult = requiredField(value, vm, customParams) as FieldValidationResult;
+
+      // Assert
+      expect(validationResult.succeeded).to.be.false;
+      expect(validationResult.type).to.be.equals('REQUIRED');
+      expect(validationResult.errorMessage).to.be.equals('Please fill in this mandatory field.');
+    });
+
+    it('should return false if value is undefined', () => {
+      // Arrange
+      const value = undefined;
+      const vm = undefined;
+      const customParams: RequiredParams = undefined;
+
+      // Act
+      const validationResult = requiredField(value, vm, customParams) as FieldValidationResult;
+
+      // Assert
+      expect(validationResult.succeeded).to.be.false;
+      expect(validationResult.type).to.be.equals('REQUIRED');
+      expect(validationResult.errorMessage).to.be.equals('Please fill in this mandatory field.');
+    });
+
+    it('should return false if value is false', () => {
+      // Arrange
+      const value = false;
+      const vm = undefined;
+      const customParams: RequiredParams = undefined;
+
+      // Act
+      const validationResult = requiredField(value, vm, customParams) as FieldValidationResult;
+
+      // Assert
+      expect(validationResult.succeeded).to.be.false;
+      expect(validationResult.type).to.be.equals('REQUIRED');
+      expect(validationResult.errorMessage).to.be.equals('Please fill in this mandatory field.');
+    });
+
+    it('should return true if value is true', () => {
+      // Arrange
+      const value = true;
+      const vm = undefined;
+      const customParams: RequiredParams = undefined;
+
+      // Act
+      const validationResult = requiredField(value, vm, customParams) as FieldValidationResult;
+
+      // Assert
+      expect(validationResult.succeeded).to.be.true;
+      expect(validationResult.type).to.be.equals('REQUIRED');
+      expect(validationResult.errorMessage).to.be.empty;
+    });
+
+  });
+
+  describe('When validating a string value', () => {
+    it('should return false if string is empty', () => {
+      // Arrange
+      const value = '';
+      const vm = undefined;
+      const customParams: RequiredParams = undefined;
+
+      // Act
+      const validationResult = requiredField(value, vm, customParams) as FieldValidationResult;
+
+      // Assert
+      expect(validationResult.succeeded).to.be.false;
+      expect(validationResult.type).to.be.equals('REQUIRED');
+      expect(validationResult.errorMessage).to.be.equals('Please fill in this mandatory field.');
+    });
+
+    it('should return true if string has whitespace characters and trim option is false', () => {
+      // Arrange
+      const value = ' ';
+      const vm = undefined;
+      const customParams: RequiredParams = { trim: false };
+
+      // Act
+      const validationResult = requiredField(value, vm, customParams) as FieldValidationResult;
+
+      // Assert
+      expect(validationResult.succeeded).to.be.true;
+      expect(validationResult.type).to.be.equals('REQUIRED');
+      expect(validationResult.errorMessage).to.be.empty;
+    });
+
+    it('should return true if string has whitespace characters and trim option is null', () => {
+      // Arrange
+      const value = ' ';
+      const vm = undefined;
+      const customParams: RequiredParams = { trim: null };
+
+      // Act
+      const validationResult = requiredField(value, vm, customParams) as FieldValidationResult;
+
+      // Assert
+      expect(validationResult.succeeded).to.be.true;
+      expect(validationResult.type).to.be.equals('REQUIRED');
+      expect(validationResult.errorMessage).to.be.empty;
+    });
+
+    it('should return true if string has whitespace characters and trim option is undefined', () => {
+      // Arrange
+      const value = ' ';
+      const vm = undefined;
+      const customParams: RequiredParams = { trim: undefined };
+
+      // Act
+      const validationResult = requiredField(value, vm, customParams) as FieldValidationResult;
+
+      // Assert
+      expect(validationResult.succeeded).to.be.true;
+      expect(validationResult.type).to.be.equals('REQUIRED');
+      expect(validationResult.errorMessage).to.be.empty;
+    });
+
+    it('should return false if string has whitespace characters and trim option is true', () => {
+      // Arrange
+      const value = ' ';
+      const vm = undefined;
+      const customParams: RequiredParams = { trim: true };
+
+      // Act
+      const validationResult = requiredField(value, vm, customParams) as FieldValidationResult;
+
+      // Assert
+      expect(validationResult.succeeded).to.be.false;
+      expect(validationResult.type).to.be.equals('REQUIRED');
+      expect(validationResult.errorMessage).to.be.equals('Please fill in this mandatory field.');
+    });
+  });
+});

--- a/lib/src/rules/spec/required.spec.ts
+++ b/lib/src/rules/spec/required.spec.ts
@@ -140,5 +140,20 @@ describe('[required] validation rule tests =>', () => {
       expect(validationResult.type).to.be.equals('REQUIRED');
       expect(validationResult.errorMessage).to.be.equals('Please fill in this mandatory field.');
     });
+
+    it('should trim by default', () => {
+      // Arrange
+      const value = ' ';
+      const vm = undefined;
+      const customParams = undefined;
+
+      // Act
+      const validationResult = required(value, vm, customParams) as FieldValidationResult;
+
+      // Assert
+      expect(validationResult.succeeded).to.be.false;
+      expect(validationResult.type).to.be.equals('REQUIRED');
+      expect(validationResult.errorMessage).to.be.equals('Please fill in this mandatory field.');
+    });
   });
 });

--- a/samples/react/00 SimpleForm/src/components/sampleForm/validations/customerFormValidation.ts
+++ b/samples/react/00 SimpleForm/src/components/sampleForm/validations/customerFormValidation.ts
@@ -1,21 +1,16 @@
-import { FieldValidationResult, createFormValidation, ValidationConstraints } from 'lc-form-validation';
+import {
+  ValidationConstraints,
+  Validators,
+  createFormValidation,
+  RequiredParams,
+} from 'lc-form-validation';
 
 // TODO: Implement Issue #17
 // TODO: Implement Issue #6
-function requiredField(value: string): FieldValidationResult {
-  const succeeded = (value && value.trim().length > 0);
-  const errorMessage = (succeeded) ? "" : "Mandatory field";
-
-  return {
-    type: 'REQUIRED',
-    succeeded,
-    errorMessage
-  };
-}
 const customerValidationConstraints: ValidationConstraints = {
   fields: {
     fullname: [
-      { validator: requiredField }
+      { validator: Validators.required }
     ]
   }
 };

--- a/samples/react/01 SignupForm/src/actions/signupUIOnInteractionStart.ts
+++ b/samples/react/01 SignupForm/src/actions/signupUIOnInteractionStart.ts
@@ -1,9 +1,9 @@
 import { FieldValidationResult } from 'lc-form-validation';
 import { signupUIOnInteractionCompleted } from './signupUIOnInteractionCompleted';
 import { signupFormValidation } from '../components/sampleSignupForm/validations/signupFormValidation';
-import { ValidationFilters } from 'lc-form-validation';
+import { ValidationEventsFilter } from 'lc-form-validation';
 
-export function signupUIOnInteractionStart(viewModel: any, fieldName: string, value: any, eventsFilter?: ValidationFilters) {
+export function signupUIOnInteractionStart(viewModel: any, fieldName: string, value: any, eventsFilter?: ValidationEventsFilter) {
   return (dispatcher) => {
     signupFormValidation.validateField(viewModel, fieldName, value, eventsFilter).then(
       function (fieldValidationResult: FieldValidationResult) {

--- a/samples/react/01 SignupForm/src/components/sampleSignupForm/sampleSignupForm.container.ts
+++ b/samples/react/01 SignupForm/src/components/sampleSignupForm/sampleSignupForm.container.ts
@@ -3,7 +3,7 @@ import { SampleSignupForm } from './sampleSignupForm';
 import { SignupEntity } from '../../entity/signupEntity';
 import { signupRequestStart } from '../../actions/signupRequestStart';
 import { signupUIOnInteractionStart } from '../../actions/signupUIOnInteractionStart';
-import { ValidationFilters } from 'lc-form-validation';
+import { ValidationEventsFilter } from 'lc-form-validation';
 
 let mapStateToProps = (state) => {
   return {
@@ -14,7 +14,7 @@ let mapStateToProps = (state) => {
 
 let mapDispatchToProps = (dispatch) => {
   return {
-    fireValidationField: (viewModel: any, fieldName: string, value: any, filter?: ValidationFilters) => {
+    fireValidationField: (viewModel: any, fieldName: string, value: any, filter?: ValidationEventsFilter) => {
       return dispatch(signupUIOnInteractionStart(viewModel, fieldName, value, filter));
     },
     performSignup: (signup: SignupEntity) => {

--- a/samples/react/01 SignupForm/src/components/sampleSignupForm/sampleSignupForm.tsx
+++ b/samples/react/01 SignupForm/src/components/sampleSignupForm/sampleSignupForm.tsx
@@ -2,17 +2,17 @@ import * as React from 'react';
 import { Input } from '../common/input';
 import { SignupEntity } from '../../entity/signupEntity';
 import { SignupErrors } from '../../entity/signupErrors';
-import { ValidationFilters } from 'lc-form-validation';
+import { ValidationEventsFilter } from 'lc-form-validation';
 
 interface Props extends React.Props<any> {
   signup: SignupEntity;
   errors: SignupErrors;
-  fireValidationField: (viewModel: any, fieldName: string, value: string, filter?: ValidationFilters) => void;
+  fireValidationField: (viewModel: any, fieldName: string, value: string, filter?: ValidationEventsFilter) => void;
   performSignup: (signup: SignupEntity) => void;
 }
 
 export class SampleSignupForm extends React.Component<Props, {}> {
-  private applyFieldValidation(event, filter?: ValidationFilters) {
+  private applyFieldValidation(event, filter?: ValidationEventsFilter) {
     const { name, value } = event.target;
     this.props.fireValidationField(this.props.signup, name, value, filter);
   }

--- a/samples/react/01 SignupForm/src/components/sampleSignupForm/validations/signupFormValidation.ts
+++ b/samples/react/01 SignupForm/src/components/sampleSignupForm/validations/signupFormValidation.ts
@@ -4,23 +4,13 @@ import {
   FieldValidationResult,
   ValidationConstraints,
   FieldValidationFunction,
+  LengthParams,
+  Validators,
 } from 'lc-form-validation';
 import { gitHub } from '../../../api/gitHub';
 
-function requiredValidationHandler(value: string): FieldValidationResult {
-  const isFieldInformed = (value && value.trim().length > 0);
-  const errorInfo = (isFieldInformed) ? '' : 'Mandatory field';
-
-  const fieldValidationResult: FieldValidationResult = new FieldValidationResult();
-  fieldValidationResult.type = 'REQUIRED';
-  fieldValidationResult.succeeded = isFieldInformed;
-  fieldValidationResult.errorMessage = errorInfo;
-
-  return fieldValidationResult;
-}
-
 function passwordAndConfirmPasswordValidationHandler(value: any, vm: any): FieldValidationResult {
-  const passwordAndConfirmPasswordAreEqual: boolean = vm.password === value;
+  const passwordAndConfirmPasswordAreEqual = vm.password === value;
   const errorInfo: string = (passwordAndConfirmPasswordAreEqual) ? '' : 'Passwords do not match';
 
   const fieldValidationResult: FieldValidationResult = new FieldValidationResult();
@@ -45,40 +35,22 @@ function resolveLoginExists(loginExists: boolean): Promise<FieldValidationResult
   return Promise.resolve(fieldValidationResult);
 }
 
-interface lengthConstraintParams {
-  minLength: number;
-}
-const lengthConstraint: lengthConstraintParams = {
-  minLength: 4
-};
-const minLengthValidationHandler: FieldValidationFunction = (password: string, vm, customParams: lengthConstraintParams) => {
-  const { minLength } = customParams;
-  const isValidMinLength = password.length >= minLength;
-  const minLengthErrorMessage = `Minimum ${minLength} characters required`;
-  const errorMessage = isValidMinLength ? '' : minLengthErrorMessage;
-  const fieldValidationResult: FieldValidationResult = new FieldValidationResult();
-  fieldValidationResult.type = 'PASSWORD_LENGTH';
-  fieldValidationResult.succeeded = isValidMinLength;
-  fieldValidationResult.errorMessage = errorMessage;
-  return Promise.resolve(fieldValidationResult);
-};
-
 const signupValidationConstraints: ValidationConstraints = {
   fields: {
     password: [
-      { validator: requiredValidationHandler },
+      { validator: Validators.required },
       {
-        validator: minLengthValidationHandler,
-        customParams: lengthConstraint,
+        validator: Validators.minLength,
+        customParams: { length: 4 } as LengthParams,
       },
     ],
     confirmPassword: [
-      { validator: requiredValidationHandler },
+      { validator: Validators.required },
       { validator: passwordAndConfirmPasswordValidationHandler },
     ],
     login: [
       {
-        validator: requiredValidationHandler,
+        validator: Validators.required,
         eventFilters: { OnChange: true, OnBlur: true },
       },
       {


### PR DESCRIPTION
There was implemented next rules:
- **required**: Returns `true` given `true` value (for checkboxes) and non-empty string (trimed by default, can be changed with `{ customParams: { trim: false } }`. Returns `false` for falsy values.
- **minLength**: Returns `true` if given value is string and its length is lesser or equals that given `length` option in `{ customParams: { length: <number> } }`. `null` and `undefined` return `true` (intended behaviour to treat them as uninitialized values). Returns false if mentioned conditions are not met.
- **maxLength**: Returns `true` if given value is string and its length is greater or equals that given `length` option in `{ customParams: { length: <number> } }`. `null` and `undefined` return `true` (intended behaviour to treat them as uninitialized values). Returns false if mentioned conditions are not met.
- **email**:  Returns `true` if value is a `string` and matches the RegExp. Otherwise, it returns `false`.
- **pattern**: Returns `true` if given value matches with the described pattern in `{ customParams: { pattern: <RegExp | string> } }`. If given pattern is a `string` it will be treated as a full RegExp (NEED REVISION HERE).