### PR TITLE
Consider numbers in the required validator

### DIFF
--- a/lib/src/rules/required.ts
+++ b/lib/src/rules/required.ts
@@ -17,7 +17,7 @@ export const required: FieldValidationFunction = (value, vm, customParams: Requi
 function isValidField(value, trim: boolean): boolean {
   return typeof value === 'string' ?
     isStringValid(value, trim) :
-    value === true;
+    value === true || typeof value === "number";
 }
 
 function isStringValid(value: string, trim: boolean): boolean {

--- a/lib/src/rules/spec/required.spec.ts
+++ b/lib/src/rules/spec/required.spec.ts
@@ -63,6 +63,20 @@ describe('[required] validation rule tests =>', () => {
       expect(validationResult.errorMessage).to.be.empty;
     });
 
+    it('should return true if typeof value is number', () => {
+      // Arrange
+      const value = 1;
+      const vm = undefined;
+      const customParams: RequiredParams = undefined;
+
+      // Act
+      const validationResult = required(value, vm, customParams) as FieldValidationResult;
+
+      // Assert
+      expect(validationResult.succeeded).to.be.true;
+      expect(validationResult.type).to.be.equals('REQUIRED');
+      expect(validationResult.errorMessage).to.be.empty;
+    });
   });
 
   describe('When validating a string value', () => {


### PR DESCRIPTION
The data model binded to the form may contain numerical attributes that are not being considered in the "required" validator